### PR TITLE
handle browse access for annotation requests

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -795,6 +795,7 @@ export class PrometheusDatasource
       const timeValueTuple: Array<[number, number]> = [];
 
       let idx = 0;
+      let previousTimestamp: number;
       valueField.values.toArray().forEach((value: string) => {
         let timeStampValue: number;
         let valueValue: number;
@@ -808,9 +809,11 @@ export class PrometheusDatasource
           timeStampValue = Math.floor(parseFloat(time));
           valueValue = parseFloat(value);
         }
-
         idx++;
-        timeValueTuple.push([timeStampValue, valueValue]);
+        if (!isNaN(timeStampValue) && timeStampValue !== previousTimestamp) {
+          timeValueTuple.push([timeStampValue, valueValue]);
+          previousTimestamp = timeStampValue;
+        }
       });
 
       const activeValues = timeValueTuple.filter((value) => value[1] >= 1);
@@ -849,7 +852,6 @@ export class PrometheusDatasource
         eventList.push(latestEvent);
       }
     }
-
     return eventList;
   };
 

--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -711,6 +711,33 @@ export class PrometheusDatasource
     }
 
     const step = options.annotation.step || ANNOTATION_QUERY_STEP_DEFAULT;
+    if (this.access === 'direct') {
+      const start = this.getPrometheusTime(options.range.from, false);
+      const end = this.getPrometheusTime(options.range.to, true);
+      const queryOptions = { ...options, interval: step };
+
+      const queryModel = {
+        expr,
+        interval: step,
+        refId: 'X',
+        requestId: `prom-query-${annotation.name}`,
+      };
+      const query = this.createQuery(queryModel, queryOptions, start, end);
+      return await lastValueFrom(
+        this.performTimeSeriesQuery(query, query.start, query.end).pipe(
+          map((response: FetchResponse<PromDataSuccessResponse<PromMatrixData>>) => {
+            const frames: DataFrame[] = transform(response, {
+              query: query,
+              target: queryModel,
+              responseListLength: 1,
+              exemplarTraceIdDestinations: this.exemplarTraceIdDestinations,
+            });
+            return this.processAnnotationResponse(options, frames);
+          })
+        )
+      );
+    }
+
     const queryModel = {
       expr,
       range: true,
@@ -736,14 +763,14 @@ export class PrometheusDatasource
         })
         .pipe(
           map((rsp: FetchResponse<BackendDataSourceResponse>) => {
-            return this.processAnnotationResponse(options, rsp.data);
+            const frames: DataFrame[] = toDataQueryResponse({ data: rsp.data }).data;
+            return this.processAnnotationResponse(options, frames);
           })
         )
     );
   }
 
-  processAnnotationResponse = (options: any, data: BackendDataSourceResponse) => {
-    const frames: DataFrame[] = toDataQueryResponse({ data: data }).data;
+  processAnnotationResponse = (options: any, frames: DataFrame[]) => {
     if (!frames || !frames.length) {
       return [];
     }


### PR DESCRIPTION
This is only used for internal reviews, will add unit tests and send a more formal PR to upstream.